### PR TITLE
Fix rendering of keyFingerprint object in React components

### DIFF
--- a/client/src/screens/ConversationsScreen.js
+++ b/client/src/screens/ConversationsScreen.js
@@ -477,7 +477,7 @@ const ConversationsScreen = () => {
           
           {encryptionStatus === 'active' && keyFingerprint && (
             <EncryptionFingerprint>
-              Key Fingerprint: {keyFingerprint}
+              Key Fingerprint: {keyFingerprint.hex ? keyFingerprint.hex : JSON.stringify(keyFingerprint)}
             </EncryptionFingerprint>
           )}
           


### PR DESCRIPTION
This commit fixes runtime errors that occurred when visiting /messages due to attempts to directly render an object with hex and numeric properties as a React child. Modified ConversationsScreen to properly display the fingerprint hex value instead of attempting to render the entire object. #39

resolves #39 